### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 google2ubuntu
 =============
 
-#UPDATE
+# UPDATE
 
 I've updated google2ubuntu in order to be able to use the google web speech api v2. You need to request a key to google.
 
-#Presentation
+# Presentation
 
 The aim of this project is to let you use the Google speech recognition API to control your linux computer. The project is developed in Python.
 
@@ -21,7 +21,7 @@ I've done huge efforts to make the program easy to install and easy to use. Besi
 # Special thanks
 Before I begin, I want to thank some of you that help me.
 
-##Contributors
+## Contributors
 Devs | Translators | Bug reports
 -----| ----- | -----
 [tectas](https://github.com/tectas)|[tectas](https://github.com/tectas)|[bmeznarsic](https://github.com/bmeznarsic) 
@@ -30,7 +30,7 @@ Devs | Translators | Bug reports
 [ladios](https://github.com/ladios)|[ladios](https://github.com/ladios)|[mads5408](https://github.com/mads5408)
 Josh Chen|[Frank Claessen](https://github.com/frankclaessen)|
 
-##Publication
+## Publication
 
 * [WebUpd8](http://www.webupd8.org/2014/02/linux-speech-recognition-using-google.html#more)
 * [La vache libre](http://la-vache-libre.org/google2ubuntu-le-projet-de-reconnaissance-vocale-pour-gnulinux-a-un-nouveau-developpeur/)
@@ -38,7 +38,7 @@ Josh Chen|[Frank Claessen](https://github.com/frankclaessen)|
 
 
 
-#Installation
+# Installation
 ## Dependancies
 
 For the moment, dependancies are:
@@ -58,7 +58,7 @@ If you are installing google2ubuntu from source not from deb or from ppa, type t
    sudo apt-get install bash python python-gi python-simplejson libsox-fmt-mp3 sox libnotify-dev acpi xdotool
 ```
 
-##Find the package
+## Find the package
 google2ubuntu is available on Github on the [release](https://github.com/benoitfragit/google2ubuntu/releases) page and in my [ppa](https://launchpad.net/~benoitfra/+archive/google2ubuntu). To install google2ubuntu 
 
 ```
@@ -67,8 +67,8 @@ sudo apt-get update
 sudo apt-get install google2ubuntu
 ```
 
-##First launch
-###Main programs
+## First launch
+### Main programs
 Once you have installed google2ubuntu, you can attribute a shortcut to those 2 Python scripts:
 
 ```
@@ -84,7 +84,7 @@ After that, you can launch google2ubuntu-manager.py in order to manage all comma
 
 As you can see, google2ubuntu comes with several default commands. I will explain you how to manage and add commands.
 
-###Basic configs
+### Basic configs
 Then you can configure google2ubuntu by clicking on the **Setup** button, that will open a window
 ![setup](http://pix.toile-libre.org/upload/original/1392400825.png)
 
@@ -97,9 +97,9 @@ In this window you can:
 
 For the last two parameters, as there is a lot of media player (vlc, mplayer, banshee, ...) I think this way is the most efficient because it lets anybody writing a basic shell script that will pause or play his favorite media player. So those commands could be shell commands or could be more elaborated scripts
 
-#Manage commands
+# Manage commands
 
-##Commands' storage
+## Commands' storage
 By default, google2ubuntu comes with several commands stored in a default xml file:
 ```
 /usr/share/google2ubuntu/config/<your_language>/default.xml
@@ -116,7 +116,7 @@ The first time you add, modify or remove a command, your commands' configuration
 ```
 
 
-##Commands' description
+## Commands' description
 A command is a pair of `key` and `action`. Each `key` referes to an `action`. Many `key` can leads to the same `action`.
 To define a command, you do not need to make explicitaly all the word you will tell, I mean, if I want to create the command:
 ```
@@ -137,7 +137,7 @@ I've implemented different types of command:
 * **internal commands**
 * **modules**
 
-###External commands
+### External commands
 
 External commands are basically commands that you can run in your terminal:
 ```
@@ -145,8 +145,8 @@ exo-open --launch MailReader
 ```
 If you want to add an external command, just click on the "Add" button. Then find the newline and replace "your key" by the key you want to associate to the command and replace "your command" by the action.
 
-###Internal commands
-####What are they ?
+### Internal commands
+#### What are they ?
 Internal commands are commands that I've implemented in google2ubuntu, for the moment there is 3 internal commands:
 
 | Name | Function | 
@@ -159,14 +159,14 @@ Internal commands are commands that I've implemented in google2ubuntu, for the m
 
 If you want to add an internal command, open the little menu near the "Add" button and select "internal". Then replace "your key" by the "key" you will pronounce to call this command and replace "word" by one of those 5 actions' name. 
 
-####Some words about dictation mode
+#### Some words about dictation mode
 
 The dictation mode let you type all word you pronouce. If you want to enter in the dictation mode use the dictation mode internal function. If you want to exit this mode just use the associated function. Dictation is not continue so you have to launch google2ubuntu for each sentence you want to type
 
-###Modules
+### Modules
 In order to extand google2ubuntu very easily I've implemented a system of modules that lets developers adds their own scripts in google2ubuntu. Besides, all modules will receive the text that you pronounce in parameter
 
-####Module's description
+#### Module's description
 A module is basically, an executable file that will receive some text in argument. each module embed its configuration in your configuration file. Two fields are recorded for each module:
 
 * linker
@@ -178,7 +178,7 @@ So, the google module will be call with `who is barack obama` in parameter.
 * spacebyplus
 If spacebyplus=1 then space are replace py +.
 
-####How to add a module
+#### How to add a module
 If you want to add a script,  the gui will help you to create one and will place the module in :
 ```
 ~/.config/google2ubuntu/modules
@@ -188,7 +188,7 @@ You can add a module by opening the menu near to the "Add" button then selecting
 Yu can also simply drag&drop this executable on the treeview and the module will be automatically added. When you add a new module you don't have to modify the `action` field in the newline. You just have to modify the `key` field in the gui.
 
 
-####Already available
+#### Already available
 google2ubuntu already comes with 6 modules:
 
 * **google**
@@ -214,19 +214,19 @@ meaning barack obama
 ```
 The plugin will tell me that he is the actual president of the US
 
-####Note for the user
+#### Note for the user
 Perhaps, you will have to modify the linker field of those module by selecting the module and clicking on the edit button
 
-#Go Linux automation
+# Go Linux automation
 Once you have personalized and take care about the commands already included in google2ubuntu, you can launch the recognition by launching `google2ubuntu.py`
 
 A little sound is played and a notification tell you to speak. Then the notification show the result and the action associated to the text you have pronounced is played.
 
-#How-to contribute
-##Design some modules
+# How-to contribute
+## Design some modules
 If you want you can write a module that will be integrated in the Github page, the user will have to download it and will be able to use it
-##Translate the app
-###Translate the google2ubuntu core
+## Translate the app
+### Translate the google2ubuntu core
 If you want to translate this app, you need first to download the [project](https://github.com/benoitfragit/google2ubuntu/archive/master.zip) then unzip it and open a terminal and place yourself in the folder newly created. Then, be sure that all string that you want to translate are like that:
 ```
 _('text to translate')
@@ -253,7 +253,7 @@ msgfmt ./i18n/<new_language>/LC_MESSAGES/google2ubuntu.po --output-file ./i18n/<
 ```
 
 
-###Update the translation
+### Update the translation
 To update an existing translation, you have to do several actions:
 ```
 xgettext --language=Python --keyword=_ --output=./i18n/google2ubuntu.pot ./*.py librairy/*.py
@@ -277,7 +277,7 @@ alt="google2ubuntu" width="480" height="360" border="5" /></a>
 I've wrote a documentation page with Sphinx
 [Documentation](http://benoitfragit.github.io/google2ubuntu/)
 
-#Update
+# Update
 
 ## Improvements
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
